### PR TITLE
base.html

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -102,7 +102,7 @@
 							{% endfor %}
 
 							{% if DISPLAY_PAGES_ON_MENU %}
-							    {% for p in PAGES %}
+							    {% for p in pages %}
 							        <li{% if p == page %} class="active"{% endif %}><a href="{{ SITEURL }}/{{ p.url }}">{{ p.title }}</a></li>
 							    {% endfor %}
 							{% elif DISPLAY_CATEGORIES_ON_MENU %}


### PR DESCRIPTION
Fixed Pages not Showing on Top menu, cause by  PAGES in capital letters at line 105,
replaced by lowercase pages 
Pelican is case sensitive and considers PAGES (capital letters) folder as articles folder instead of static pages (lower letters) folder

Working fine now.