### PR TITLE
style.css

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2079,7 +2079,7 @@ html[xmlns] .slides {display: block;}
 	left: 38%
 }
 
-.post-content { margin: -57px 0 0 89px }
+.post-content { margin: 0 0 0 89px }
 .medium .post-content {margin:0;}
 .post-content h2 a { color: #505050; }
 .post-content h2 a:hover { color: #707070; }


### PR DESCRIPTION
line 2002 margin -52 causing article content to be almost on top of breadcrumbs 
Changed to 0 , looking fine now